### PR TITLE
Concurrency support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ any other tables applications built on top of this package may use.
 
 Commands use an ordinal identifier to ensure that they're processed in order of insertion. This is an implementation
 detail not exposed to users of the package. Once processed, their entry in the `pgfsm.command` table is removed,
-providing once-only processing of individual commands.
+providing once-only processing of individual commands. When using a concurrency of greater than one, this package
+provides at-least-once processing of commands in batches. Batches of commands are dependent on eachother as they are
+handled within the same transaction. If a single command within the batch fails, all commands in the batch are returned
+to the database.
 
-When reading commands, a transaction is used to ensure that should command processing fail, the contents of the command
-are returned to the `pgfsm.command` table with the same identifier. This package uses a registration system for commands
-utilising parameterised types that allows commands to be directly decoded into their concrete types without excessive
-usage of reflection.
+This package uses a registration system for commands utilising parameterised types that allows commands to be directly
+decoded into their concrete types without excessive usage of reflection.
 
 When handling a command, you have the option to return a command as a result. This allows commands to act as a graph of
 sorts. Where the successful processing of one command creates zero or more child commands. This can be used to define


### PR DESCRIPTION
This commit provides a new option named SetConcurrency that allows the user of the package to specify the number of queued commands to process concurrently. This effectively adds batching with some slight differences.

Mainly, commands in a batch are all managed within a single database transaction, so are dependent on each other's success. If any one command in the batch fails then all commands in the batch will return to the queue. This makes idempotency quite important.

I wanted to add this kind of batching as I figured you could end up in situations where all instances of the FSM get blocked waiting on a chain of dependent commands, so allowing nodes to process large amounts of commands in a batch can help mitigate that problem.